### PR TITLE
Add user page and avatar link

### DIFF
--- a/src/app/[user_id]/page.tsx
+++ b/src/app/[user_id]/page.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image";
+import { prisma } from "@/lib/prisma";
+import { fetchTopGenres } from "@/lib/spotify";
+
+interface PageProps {
+  params: { user_id: string };
+}
+
+export default async function UserPage({ params }: PageProps) {
+  const { user_id } = params;
+  const user = await prisma.user.findUnique({
+    where: { id: user_id },
+    include: { accounts: true },
+  });
+
+  if (!user) {
+    return (
+      <main className="p-6 text-white bg-neutral-900 min-h-screen">
+        <h1 className="text-2xl">Пользователь не найден</h1>
+      </main>
+    );
+  }
+
+  const account = user.accounts.find((a) => a.provider === "spotify");
+  let genres: string[] = [];
+  if (account?.access_token) {
+    try {
+      genres = await fetchTopGenres(account.access_token, "medium_term");
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  return (
+    <main className="p-6 text-white bg-neutral-900 min-h-screen space-y-4">
+      <div className="flex items-center gap-4">
+        {user.image && (
+          <Image
+            src={user.image}
+            alt={user.name ?? "avatar"}
+            width={64}
+            height={64}
+            className="rounded-full"
+          />
+        )}
+        <h1 className="text-2xl">{user.name ?? "Unknown User"}</h1>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Любимые жанры</h2>
+        {genres.length > 0 ? (
+          <ul className="list-disc pl-6">
+            {genres.map((g) => (
+              <li key={g}>{g}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-400">Нет данных</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,9 @@ export default function Header() {
       {session ? (
         <div className="flex items-center gap-4">
           {session.user?.image && (
-            <Image src={session.user.image} alt="avatar" width={32} height={32} className="rounded-full" />
+            <Link href={`/${(session.user as any).id}`}> 
+              <Image src={session.user.image} alt="avatar" width={32} height={32} className="rounded-full" />
+            </Link>
           )}
           <span>{session.user?.name}</span>
           <button onClick={() => signOut()} className="text-sm text-gray-300 hover:underline">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,16 +19,20 @@ export const authOptions: NextAuthOptions = {
 
   callbacks: {
     // Срабатывает на первой авторизации и при обновлении JWT
-    async jwt({ token, account }) {
+    async jwt({ token, account, user }) {
       if (account) {
         token.accessToken = account.access_token;
+      }
+      if (user) {
+        (token as any).id = user.id;
       }
       return token;
     },
     // Срабатывает при getSession() / useSession() и передаёт токен в браузер
     async session({ session, token }) {
       if (session.user) {
-        (session.user as any).accessToken = token.accessToken;
+        (session.user as any).accessToken = (token as any).accessToken;
+        (session.user as any).id = (token as any).id ?? token.sub;
       }
       return session;
     },


### PR DESCRIPTION
## Summary
- create dynamic user profile route `/[user_id]`
- show top genres for the user
- expose user id in auth callbacks
- link avatar image to the current user page

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_688548940a8083229acefc4d03802968