### PR TITLE
Add user page and avatar link

### DIFF
--- a/src/app/[user_id]/page.tsx
+++ b/src/app/[user_id]/page.tsx
@@ -1,0 +1,70 @@
+import Image from "next/image";
+import { prisma } from "@/lib/prisma";
+import { fetchTopGenres, refreshSpotifyToken } from "@/lib/spotify";
+
+interface PageProps {
+  params: { user_id: string };
+}
+
+export default async function UserPage({ params }: PageProps) {
+  const { user_id } = params;
+  const user = await prisma.user.findUnique({
+    where: { id: user_id },
+    include: { accounts: true },
+  });
+
+  if (!user) {
+    return (
+      <main className="p-6 text-white bg-neutral-900 min-h-screen">
+        <h1 className="text-2xl">Пользователь не найден</h1>
+      </main>
+    );
+  }
+
+  const account = user.accounts.find((a) => a.provider === "spotify");
+  let genres: string[] = [];
+  if (account?.access_token) {
+    let token = account.access_token;
+    if (account.expires_at && account.expires_at * 1000 < Date.now()) {
+      try {
+        token = await refreshSpotifyToken(account.id, account.refresh_token ?? "");
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    try {
+      genres = await fetchTopGenres(token, "medium_term");
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  return (
+    <main className="p-6 text-white bg-neutral-900 min-h-screen space-y-4">
+      <div className="flex items-center gap-4">
+        {user.image && (
+          <Image
+            src={user.image}
+            alt={user.name ?? "avatar"}
+            width={64}
+            height={64}
+            className="rounded-full"
+          />
+        )}
+        <h1 className="text-2xl">{user.name ?? "Unknown User"}</h1>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Любимые жанры</h2>
+        {genres.length > 0 ? (
+          <ul className="list-disc pl-6">
+            {genres.map((g) => (
+              <li key={g}>{g}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-400">Нет данных</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -4,14 +4,14 @@ import { fetchTopGenres } from '@/lib/spotify'
 
 export default async function Favorites() {
   const session = await getServerSession(authOptions)
-  if (!session || !(session.user as any).accessToken) {
+  if (!session || !session.user?.accessToken) {
     return (
       <main className="p-6 text-white bg-neutral-900 min-h-screen">
         <p>Необходимо войти в систему.</p>
       </main>
     )
   }
-  const token = (session.user as any).accessToken as string
+  const token = session.user.accessToken as string
   const [short, medium, long] = await Promise.all([
     fetchTopGenres(token, 'short_term'),
     fetchTopGenres(token, 'medium_term'),

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,9 @@ export default function Header() {
       {session ? (
         <div className="flex items-center gap-4">
           {session.user?.image && (
-            <Image src={session.user.image} alt="avatar" width={32} height={32} className="rounded-full" />
+            <Link href={`/${session.user.id}`}>
+              <Image src={session.user.image} alt="avatar" width={32} height={32} className="rounded-full" />
+            </Link>
           )}
           <span>{session.user?.name}</span>
           <button onClick={() => signOut()} className="text-sm text-gray-300 hover:underline">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,16 +19,20 @@ export const authOptions: NextAuthOptions = {
 
   callbacks: {
     // Срабатывает на первой авторизации и при обновлении JWT
-    async jwt({ token, account }) {
+    async jwt({ token, account, user }) {
       if (account) {
         token.accessToken = account.access_token;
+      }
+      if (user) {
+        token.id = user.id;
       }
       return token;
     },
     // Срабатывает при getSession() / useSession() и передаёт токен в браузер
     async session({ session, token }) {
       if (session.user) {
-        (session.user as any).accessToken = token.accessToken;
+        session.user.accessToken = token.accessToken;
+        session.user.id = token.id ?? token.sub;
       }
       return session;
     },

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/prisma";
 export async function fetchTopGenres(
   accessToken: string,
   timeRange: "short_term" | "medium_term" | "long_term"
@@ -11,7 +12,7 @@ export async function fetchTopGenres(
   }
   const data = await res.json();
   const counts: Record<string, number> = {};
-  for (const artist of data.items as any[]) {
+  for (const artist of data.items as { genres: string[] }[]) {
     for (const genre of artist.genres as string[]) {
       counts[genre] = (counts[genre] || 0) + 1;
     }
@@ -20,4 +21,43 @@ export async function fetchTopGenres(
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5)
     .map(([g]) => g);
+}
+
+/**
+ * Refresh Spotify access token using a stored refresh token.
+ * Returns the new access token and updates the account in the database.
+ */
+export async function refreshSpotifyToken(
+  accountId: string,
+  refreshToken: string
+) {
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: process.env.SPOTIFY_CLIENT_ID ?? "",
+      client_secret: process.env.SPOTIFY_CLIENT_SECRET ?? "",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error("Failed to refresh token");
+  }
+  const data = (await res.json()) as {
+    access_token: string;
+    expires_in: number;
+    refresh_token?: string;
+  };
+  await prisma.account.update({
+    where: { id: accountId },
+    data: {
+      access_token: data.access_token,
+      expires_at: Math.floor(Date.now() / 1000) + data.expires_in,
+      refresh_token: data.refresh_token ?? refreshToken,
+    },
+  });
+  return data.access_token;
 }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,18 @@
+import { DefaultSession } from "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user?: {
+      id?: string;
+      accessToken?: string;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string;
+    accessToken?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- create dynamic user profile route `/[user_id]`
- show top genres for the user
- expose user id in auth callbacks
- link avatar image to the current user page
- refresh Spotify tokens when expired
- type custom fields on session and token

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688548940a8083229acefc4d03802968